### PR TITLE
Update user_config_override.h

### DIFF
--- a/tasmota/user_config_override.h
+++ b/tasmota/user_config_override.h
@@ -4191,7 +4191,7 @@ o888o        o888ooooood8 o88o     o8888o     o888o     o888o o8o        `8     
  #define USE_IAQ                                // [I2cDriver46] Enable iAQ-core air quality sensor (I2C address 0x5a) (+0k6 code)
  //#define USE_AS3935                              // [I2cDriver48] Enable AS3935 Franklin Lightning Sensor (I2C address 0x03) (+5k4 code)
 
- /*#define USE_DISPLAY                            // Add I2C Display Support (+2k code)
+ //#define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0
     #define USE_DISPLAY_LCD                      // [DisplayModel 1] [I2cDriver3] Enable Lcd display (I2C addresses 0x27 and 0x3F) (+6k code)
     #define USE_DISPLAY_SSD1306                  // [DisplayModel 2] [I2cDriver4] Enable SSD1306 Oled 128x64 display (I2C addresses 0x3C and 0x3D) (+16k code)
@@ -4206,16 +4206,14 @@ o888o        o888ooooood8 o88o     o8888o     o888o     o888o o8o        `8     
       #define MTX_ADDRESS8     0x00              // [DisplayAddress8] I2C address of eigth 8x8 matrix module
       #define USE_DISPLAY_SEVENSEG               // [DisplayModel 11] [I2cDriver47] Enable sevenseg display (I2C 0x70-0x77) (<+11k code)
       #define SEVENSEG_ADDRESS1     0x70         // [DisplayAddress1] I2C address of first sevenseg matrix module
-      #define USE_DISPLAY_SH1106                 // [DisplayModel 7] [I2cDriver6] Enable SH1106 Oled 128x64 display (I2C addresses 0x3C and 0x3D)*/
+      #define USE_DISPLAY_SH1106                 // [DisplayModel 7] [I2cDriver6] Enable SH1106 Oled 128x64 display (I2C addresses 0x3C and 0x3D)
 
 #endif   // USE_I2C
 
 // -- SPI sensors ---------------------------------
-#define USE_SPI                                  // Hardware SPI using GPIO12(MISO), GPIO13(MOSI) and GPIO14(CLK) in addition to two user selectable GPIOs(CS and DC)
+//#define USE_SPI                                  // Hardware SPI using GPIO12(MISO), GPIO13(MOSI) and GPIO14(CLK) in addition to two user selectable GPIOs(CS and DC)
 #ifdef USE_SPI
-  /*#ifndef USE_DISPLAY
-  #define USE_DISPLAY                          // Add SPI Display support for 320x240 and 480x320 TFT
-  #endif
+//  #define USE_DISPLAY                          // Add SPI Display support for 320x240 and 480x320 TFT
   #define USE_DISPLAY_ILI9341                  // [DisplayModel 4] Enable ILI9341 Tft 480x320 display (+19k code)
   #define USE_DISPLAY_EPAPER_29                // [DisplayModel 5] Enable e-paper 2.9 inch display (+19k code)
   #define USE_DISPLAY_EPAPER_42                // [DisplayModel 6] Enable e-paper 4.2 inch display
@@ -4223,7 +4221,7 @@ o888o        o888ooooood8 o88o     o8888o     o888o     o888o o8o        `8     
   #define USE_DISPLAY_SSD1351                  // [DisplayModel 9]
   #define USE_DISPLAY_RA8876                   // [DisplayModel 10]
   #define USE_DISPLAY_ST7789                   // [DisplayModel 12] Enable ST7789 module
-  #define USE_DISPLAY_SSD1331                  // [DisplayModel 14] Enable SSD1331 module*/
+  #define USE_DISPLAY_SSD1331                  // [DisplayModel 14] Enable SSD1331 module
 #endif  // USE_SPI
 
 // -- Serial sensors ------------------------------

--- a/tasmota/user_config_override.h
+++ b/tasmota/user_config_override.h
@@ -4191,7 +4191,7 @@ o888o        o888ooooood8 o88o     o8888o     o888o     o888o o8o        `8     
  #define USE_IAQ                                // [I2cDriver46] Enable iAQ-core air quality sensor (I2C address 0x5a) (+0k6 code)
  //#define USE_AS3935                              // [I2cDriver48] Enable AS3935 Franklin Lightning Sensor (I2C address 0x03) (+5k4 code)
 
- #define USE_DISPLAY                            // Add I2C Display Support (+2k code)
+ /*#define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0
     #define USE_DISPLAY_LCD                      // [DisplayModel 1] [I2cDriver3] Enable Lcd display (I2C addresses 0x27 and 0x3F) (+6k code)
     #define USE_DISPLAY_SSD1306                  // [DisplayModel 2] [I2cDriver4] Enable SSD1306 Oled 128x64 display (I2C addresses 0x3C and 0x3D) (+16k code)
@@ -4206,14 +4206,14 @@ o888o        o888ooooood8 o88o     o8888o     o888o     o888o o8o        `8     
       #define MTX_ADDRESS8     0x00              // [DisplayAddress8] I2C address of eigth 8x8 matrix module
       #define USE_DISPLAY_SEVENSEG               // [DisplayModel 11] [I2cDriver47] Enable sevenseg display (I2C 0x70-0x77) (<+11k code)
       #define SEVENSEG_ADDRESS1     0x70         // [DisplayAddress1] I2C address of first sevenseg matrix module
-      #define USE_DISPLAY_SH1106                 // [DisplayModel 7] [I2cDriver6] Enable SH1106 Oled 128x64 display (I2C addresses 0x3C and 0x3D)
+      #define USE_DISPLAY_SH1106                 // [DisplayModel 7] [I2cDriver6] Enable SH1106 Oled 128x64 display (I2C addresses 0x3C and 0x3D)*/
 
 #endif   // USE_I2C
 
 // -- SPI sensors ---------------------------------
 #define USE_SPI                                  // Hardware SPI using GPIO12(MISO), GPIO13(MOSI) and GPIO14(CLK) in addition to two user selectable GPIOs(CS and DC)
 #ifdef USE_SPI
-  #ifndef USE_DISPLAY
+  /*#ifndef USE_DISPLAY
   #define USE_DISPLAY                          // Add SPI Display support for 320x240 and 480x320 TFT
   #endif
   #define USE_DISPLAY_ILI9341                  // [DisplayModel 4] Enable ILI9341 Tft 480x320 display (+19k code)
@@ -4223,7 +4223,7 @@ o888o        o888ooooood8 o88o     o8888o     o888o     o888o o8o        `8     
   #define USE_DISPLAY_SSD1351                  // [DisplayModel 9]
   #define USE_DISPLAY_RA8876                   // [DisplayModel 10]
   #define USE_DISPLAY_ST7789                   // [DisplayModel 12] Enable ST7789 module
-  #define USE_DISPLAY_SSD1331                  // [DisplayModel 14] Enable SSD1331 module
+  #define USE_DISPLAY_SSD1331                  // [DisplayModel 14] Enable SSD1331 module*/
 #endif  // USE_SPI
 
 // -- Serial sensors ------------------------------


### PR DESCRIPTION
Disable Display in I2C- and SPI-section as bugfix for (current) missing webserver-gui (-->saving ROM and RAM).

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
