### PR TITLE
nspanel should use tasmota32 vanilla as base

### DIFF
--- a/platformio_tasmota_cenv.ini
+++ b/platformio_tasmota_cenv.ini
@@ -156,7 +156,7 @@ lib_extra_dirs = lib/libesp32, lib/libesp32_div, lib/libesp32_lvgl, lib/lib_basi
 board_build.f_cpu = 240000000L
 
 [env:tasmota32-nspanel]
-extends = env:tasmota32-udisplay
+extends = env:tasmota32_base
 platform_packages = framework-arduinoespressif32 @ https://github.com/tasmota/esp32-arduino-lib-builder/releases/download/2.0.2/framework-arduinoespressif32-release_v4.4-8311525486.tar.gz
 
 


### PR DESCRIPTION
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
