### PR TITLE
add i2s to mi32 env

### DIFF
--- a/platformio_tasmota_cenv.ini
+++ b/platformio_tasmota_cenv.ini
@@ -385,10 +385,9 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
                               -DUSE_BERRY_ULP
-lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl
-lib_ignore                  = ESP8266Audio
-                              ESP8266SAM
-                              Micro-RTSP
+                              -DUSE_I2S_ALL
+lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl, lib/lib_audio
+lib_ignore                  = Micro-RTSP
                               LoRa
                               RadioLib
 custom_files_upload         = ${env:tasmota32_base.custom_files_upload}
@@ -447,10 +446,9 @@ board                       = esp32c3
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
-lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl
-lib_ignore                  = ESP8266Audio
-                              ESP8266SAM
-                              Micro-RTSP
+                              -DUSE_I2S_ALL
+lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl, lib/lib_audio
+lib_ignore                  = Micro-RTSP
                               LoRa
                               RadioLib
 custom_files_upload         = ${env:tasmota32_base.custom_files_upload}
@@ -463,10 +461,10 @@ board                       = esp32c6
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
-lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl
-lib_ignore                  = ESP8266Audio
-                              ESP8266SAM
-                              Micro-RTSP
+                              -DUSE_BERRY_ULP
+                              -DUSE_I2S_ALL
+lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl, lib/lib_audio
+lib_ignore                  = Micro-RTSP
                               LoRa
                               RadioLib
 custom_files_upload         = ${env:tasmota32_base.custom_files_upload}
@@ -493,10 +491,9 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
                               -DUSE_BERRY_ULP
-lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl
-lib_ignore                  = ESP8266Audio
-                              ESP8266SAM
-                              Micro-RTSP
+                              -DUSE_I2S_ALL
+lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl, lib/lib_audio
+lib_ignore                  = Micro-RTSP
                               LoRa
                               RadioLib
 custom_files_upload         = ${env:tasmota32_base.custom_files_upload}


### PR DESCRIPTION
## Description:

See title

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250504
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configurations to include audio library support across multiple ESP32 builds.
  * Simplified ignored libraries list to retain only Micro-RTSP.
  * Adjusted build flags related to I2S and Berry ULP for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->