### PR TITLE
Update platformio_tasmota_cenv.ini to support ESP32s3 with QSPI PSRAM

### DIFF
--- a/platformio_tasmota_cenv.ini
+++ b/platformio_tasmota_cenv.ini
@@ -190,6 +190,13 @@ board_build.f_cpu           = 240000000L
 build_flags                 = ${env:tasmota32_base.build_flags} -DUSE_WEBCAM -DENABLE_RTSPSERVER -UCAMERA_MODEL_ESP32S3_EYE -DUSE_BERRY_ULP -DFIRMWARE_LVGL -DFIRMWARE_TASMOTA32
 lib_extra_dirs              = lib/libesp32, lib/libesp32_lvgl, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 
+[env:tasmota32s3-qio_qspi]
+extends                     = env:tasmota32_base
+board                       = esp32s3-qio_qspi
+board_build.f_cpu           = 240000000L
+build_flags                 = ${env:tasmota32_base.build_flags} -DUSE_WEBCAM -DENABLE_RTSPSERVER -UCAMERA_MODEL_ESP32S3_EYE -DUSE_BERRY_ULP -DFIRMWARE_LVGL -DFIRMWARE_TASMOTA32
+lib_extra_dirs              = lib/libesp32, lib/libesp32_lvgl, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
+
 [env:tasmota32s3-opi_opi]
 extends                     = env:tasmota32_base
 board                       = esp32s3-opi_opi


### PR DESCRIPTION
## Description:

added [env:tasmota32s3-qio_qspi] to support S3's with Quad SPI PSRAM, such as used by ESP32-S3FH4R2 on the ESP32s3-zero board.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new ESP32-S3 QIO/QSPI build variant, expanding device compatibility options with equivalent configuration to the base variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->